### PR TITLE
PsxPlayer changes to allow platforming

### DIFF
--- a/src/controls.hh
+++ b/src/controls.hh
@@ -86,7 +86,7 @@ class Controls {
 
     bool m_sprinting = false;
     static constexpr uint8_t m_stickDeadzone = 0x30;
-    static constexpr psyqo::Angle rotSpeed = 0.01_pi;
+    static constexpr psyqo::Angle rotSpeed = 0.02_pi;
     
     // Configurable movement speeds (set from splashpack, or defaults)
     psyqo::FixedPoint<12> m_moveSpeed = 0.002_fp;

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -2,6 +2,7 @@
 
 #include <psyqo/fixed-point.hh>
 #include <psyqo/vector.hh>
+#include <psyqo/xprintf.h>
 
 /**
  * navregion.cpp - Convex Region Navigation System
@@ -277,6 +278,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
         }
     }
 
+    /*
     // Not in current region or any neighbor — try broader search 
     // This handles jumping/falling to non-adjacent regions (e.g., landing on a platform) 
     { 
@@ -286,7 +288,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
             return getFloorY(newX, newZ, found); 
         } 
     } 
-    
+    */
 
     // Truly off all regions — clamp to current region boundary
     clampToRegion(newX, newZ, currentRegion);

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -309,7 +309,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
     */
     //printf("Region is %d\n", currentRegion);
     // Truly off all regions — clamp to current region boundary
-    //clampToRegion(newX, newZ, currentRegion);
+    clampToRegion(newX, newZ, currentRegion);
     
     return getFloorY(newX, newZ, currentRegion);
 }

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -250,7 +250,6 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
     // If no valid region, find one
     if (currentRegion == NAV_NO_REGION || currentRegion >= m_header.regionCount) {
         currentRegion = findRegionClosest(newX, newY, newZ);
-        printf("Newest Region %d \n",currentRegion);
         if (currentRegion == NAV_NO_REGION) return 0;
     }
 

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -332,12 +332,11 @@ bool NavRegionSystem::findPath(uint16_t startRegion, uint16_t endRegion,
 // ============================================================================
 
 int32_t NavRegionSystem::getYDistance(int32_t firstY, int32_t secondY){
-    // Abs
-    firstY = firstY < 0 ? -firstY : firstY;
-    secondY = secondY < 0 ? -secondY : secondY;
-
     // Difference
-    return firstY < secondY ? secondY - firstY : firstY - secondY;
+    int32_t result = firstY - secondY;
+    
+    // Abs
+    return result < 0 ? -result : result;
 }
 
 

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -177,7 +177,27 @@ uint16_t NavRegionSystem::findRegionClosest(int32_t x, int32_t y, int32_t z) con
             }
         }
     }
+    if(best >= m_header.regionCount || shortestDistance > NAV_ATTACH_DISTANCE)
+    {
+        printf("OFF NAV Best is %d Distance: %d\n",best,shortestDistance);
+        return NAV_NO_REGION;
+    }
+    
+    printf("Returning Best Nav: %d\n",best);
     return best;
+}
+
+bool NavRegionSystem::isOffNavRegion(int32_t x, int32_t y, int32_t z) const {
+    // When multiple regions overlap at the same XZ position (e.g., floor and
+    // elevated step), prefer the closest physical surface to y
+    
+    uint16_t bestRegion = findRegionClosest(x,y,z);
+    if(bestRegion == NAV_NO_REGION)
+    {
+        return true;
+    }
+
+    return false;
 }
 
 // ============================================================================
@@ -226,12 +246,10 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
                                           uint16_t& currentRegion) const {
     if (!isLoaded() || m_header.regionCount == 0) return 0;
 
-
-
     // If no valid region, find one
     if (currentRegion == NAV_NO_REGION || currentRegion >= m_header.regionCount) {
         currentRegion = findRegionClosest(newX, newY, newZ);
-
+        printf("Newest Region %d \n",currentRegion);
         if (currentRegion == NAV_NO_REGION) return 0;
     }
 
@@ -289,9 +307,10 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
         } 
     } 
     */
-
+    //printf("Region is %d\n", currentRegion);
     // Truly off all regions — clamp to current region boundary
-    clampToRegion(newX, newZ, currentRegion);
+    //clampToRegion(newX, newZ, currentRegion);
+    
     return getFloorY(newX, newZ, currentRegion);
 }
 

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -170,6 +170,10 @@ uint16_t NavRegionSystem::findRegionClosest(int32_t x, int32_t y, int32_t z) con
         if (pointInRegion(x, z, i)) {
             int32_t fy = getFloorY(x, z, i);
 
+            // Player below the region so skip
+            if(y-32 > fy){
+                continue;
+            }
             int32_t distance = getYDistance(y,fy);
             if (distance < shortestDistance) {
                 shortestDistance = distance;
@@ -179,11 +183,8 @@ uint16_t NavRegionSystem::findRegionClosest(int32_t x, int32_t y, int32_t z) con
     }
     if(best >= m_header.regionCount || shortestDistance > NAV_ATTACH_DISTANCE)
     {
-        printf("OFF NAV Best is %d Distance: %d\n",best,shortestDistance);
         return NAV_NO_REGION;
     }
-    
-    printf("Returning Best Nav: %d\n",best);
     return best;
 }
 
@@ -341,4 +342,16 @@ int32_t NavRegionSystem::getYDistance(int32_t firstY, int32_t secondY){
 }
 
 
+bool NavRegionSystem::isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegion)
+{
+    for (size_t i = 0; i < count; i++)
+    {
+        if (noWallRegions[i] == targetRegion)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
 }  // namespace psxsplash

--- a/src/navregion.cpp
+++ b/src/navregion.cpp
@@ -143,9 +143,7 @@ bool NavRegionSystem::pointInRegion(int32_t x, int32_t z, uint16_t regionIndex) 
 // ============================================================================
 
 uint16_t NavRegionSystem::findRegion(int32_t x, int32_t z) const {
-    // When multiple regions overlap at the same XZ position (e.g., floor and
-    // elevated step), prefer the highest physical surface. In PSX Y-down space,
-    // highest surface = smallest (most negative) floor Y value.
+    // Prefer the highest surface (smallest Y in Y-down space)
     uint16_t best = NAV_NO_REGION;
     int32_t bestY = 0x7FFFFFFF;
     for (uint16_t i = 0; i < m_header.regionCount; i++) {
@@ -161,8 +159,7 @@ uint16_t NavRegionSystem::findRegion(int32_t x, int32_t z) const {
 }
 
 uint16_t NavRegionSystem::findRegionClosest(int32_t x, int32_t y, int32_t z) const {
-    // When multiple regions overlap at the same XZ position (e.g., floor and
-    // elevated step), prefer the closest physical surface to y
+    // Prefer the closest surface to y, skipping regions the player is below
     
     uint16_t best = NAV_NO_REGION;
     int32_t shortestDistance = 0x7FFFFFFF;
@@ -189,9 +186,6 @@ uint16_t NavRegionSystem::findRegionClosest(int32_t x, int32_t y, int32_t z) con
 }
 
 bool NavRegionSystem::isOffNavRegion(int32_t x, int32_t y, int32_t z) const {
-    // When multiple regions overlap at the same XZ position (e.g., floor and
-    // elevated step), prefer the closest physical surface to y
-    
     uint16_t bestRegion = findRegionClosest(x,y,z);
     if(bestRegion == NAV_NO_REGION)
     {
@@ -240,6 +234,52 @@ void NavRegionSystem::clampToRegion(int32_t& x, int32_t& z, uint16_t regionIndex
 }
 
 // ============================================================================
+// Clamp position to non-walkoff boundary edges only
+// ============================================================================
+
+void NavRegionSystem::clampToRegionSelective(int32_t& x, int32_t& z, uint16_t regionIndex) const {
+    if (regionIndex >= m_header.regionCount) return;
+    const auto& reg = m_regions[regionIndex];
+
+    if (pointInConvexPoly(x, z, reg.vertsX, reg.vertsZ, reg.vertCount))
+        return; // Already inside
+
+    // Find which edge the player is closest to.
+    // If that edge is a walkoff edge, let them leave without clamping.
+    int32_t bestX = x, bestZ = z;
+    int64_t bestDistSq = 0x7FFFFFFFFFFFFFFFLL;
+    int bestEdge = -1;
+
+    for (int i = 0; i < reg.vertCount; i++) {
+        int next = (i + 1) % reg.vertCount;
+        int32_t cx, cz;
+        closestPointOnSegment(x, z,
+                              reg.vertsX[i], reg.vertsZ[i],
+                              reg.vertsX[next], reg.vertsZ[next],
+                              cx, cz);
+
+        int64_t dx = (int64_t)(x - cx);
+        int64_t dz = (int64_t)(z - cz);
+        int64_t distSq = dx * dx + dz * dz;
+
+        if (distSq < bestDistSq) {
+            bestDistSq = distSq;
+            bestX = cx;
+            bestZ = cz;
+            bestEdge = i;
+        }
+    }
+
+    // If the closest edge allows walkoff, do not clamp
+    if (bestEdge >= 0 && (reg.walkoffEdgeMask & (1 << bestEdge))) {
+        return;
+    }
+
+    x = bestX;
+    z = bestZ;
+}
+
+// ============================================================================
 // Resolve position (main per-frame call)
 // ============================================================================
 
@@ -257,10 +297,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
     if (pointInRegion(newX, newZ, currentRegion)) {
         int32_t fy = getFloorY(newX, newZ, currentRegion);
 
-        // Check if a portal neighbor has a higher floor at this position.
-        // This handles overlapping regions (e.g., floor and elevated step).
-        // When the player walks onto the step, the step region (portal neighbor)
-        // has a higher floor (smaller Y in PSX Y-down) and should take priority.
+        // Prefer portal neighbor with a higher floor (smaller Y in Y-down space)
         const auto& reg = m_regions[currentRegion];
         for (int i = 0; i < reg.portalCount; i++) {
             uint16_t portalIdx = reg.portalStart + i;
@@ -297,7 +334,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
     }
 
     /*
-    // Not in current region or any neighbor — try broader search 
+    // Not in current region or any neighbor -- try broader search 
     // This handles jumping/falling to non-adjacent regions (e.g., landing on a platform) 
     { 
         uint16_t found = findRegionClosest(newX, newY, newZ); 
@@ -308,7 +345,7 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
     } 
     */
     //printf("Region is %d\n", currentRegion);
-    // Truly off all regions — clamp to current region boundary
+    // Off all regions -- clamp to current region boundary
     clampToRegion(newX, newZ, currentRegion);
     
     return getFloorY(newX, newZ, currentRegion);
@@ -320,7 +357,6 @@ int32_t NavRegionSystem::resolvePosition(int32_t& newX, int32_t& newY, int32_t& 
 
 bool NavRegionSystem::findPath(uint16_t startRegion, uint16_t endRegion,
                                 NavPath& path) const {
-    // STUB: Returns false until NPC pathfinding is implemented.
     path.stepCount = 0;
     (void)startRegion;
     (void)endRegion;
@@ -332,24 +368,22 @@ bool NavRegionSystem::findPath(uint16_t startRegion, uint16_t endRegion,
 // ============================================================================
 
 int32_t NavRegionSystem::getYDistance(int32_t firstY, int32_t secondY){
-    // Difference
     int32_t result = firstY - secondY;
-    
-    // Abs
     return result < 0 ? -result : result;
 }
 
+// ============================================================================
+// Region flag accessors
+// ============================================================================
 
-bool NavRegionSystem::isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegion)
-{
-    for (size_t i = 0; i < count; i++)
-    {
-        if (noWallRegions[i] == targetRegion)
-        {
-            return false;
-        }
-    }
-
-    return true;
+bool NavRegionSystem::isRegionPlatform(uint16_t regionIndex) const {
+    if (regionIndex >= m_header.regionCount) return false;
+    return (m_regions[regionIndex].flags & NAV_FLAG_PLATFORM) != 0;
 }
+
+uint8_t NavRegionSystem::getWalkoffEdgeMask(uint16_t regionIndex) const {
+    if (regionIndex >= m_header.regionCount) return 0;
+    return m_regions[regionIndex].walkoffEdgeMask;
+}
+
 }  // namespace psxsplash

--- a/src/navregion.hh
+++ b/src/navregion.hh
@@ -155,7 +155,7 @@ public:
     bool findPath(uint16_t startRegion, uint16_t endRegion,
                   NavPath& path) const;
 
-    bool isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegionn);
+    bool isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegion);
 
     private:
     NavDataHeader m_header = {};

--- a/src/navregion.hh
+++ b/src/navregion.hh
@@ -24,7 +24,7 @@ static constexpr int NAV_MAX_VERTS_PER_REGION = 8;   // Max polygon verts
 static constexpr int NAV_MAX_NEIGHBORS = 8;           // Max portal edges per region
 static constexpr int NAV_MAX_PATH_STEPS = 32;         // Max A* path length
 static constexpr uint16_t NAV_NO_REGION = 0xFFFF;     // Sentinel: no region
-
+static constexpr int32_t NAV_ATTACH_DISTANCE = 1024;
 // ============================================================================
 // Surface type for navigation regions
 // ============================================================================
@@ -144,6 +144,8 @@ public:
     /// Find which region contains a point (brute-force, for initialization).
     uint16_t findRegionClosest(int32_t x, int32_t y, int32_t z) const;
 
+    /// Is the player off the nav region?
+    bool isOffNavRegion(int32_t x, int32_t y, int32_t z) const;
 
     /// Clamp an XZ position to stay within a region's polygon boundary.
     /// Returns the clamped position.

--- a/src/navregion.hh
+++ b/src/navregion.hh
@@ -7,7 +7,7 @@
  *   - Walkable surface decomposed into convex polygonal regions (XZ plane).
  *   - Adjacent regions share portal edges.
  *   - Player has a single current region index.
- *   - Movement: point-in-convex-polygon test → portal crossing → neighbor update.
+ *   - Movement: point-in-polygon test, portal crossing, neighbor update.
  *   - Floor Y: project XZ onto region's floor plane.
  */
 
@@ -25,6 +25,7 @@ static constexpr int NAV_MAX_NEIGHBORS = 8;           // Max portal edges per re
 static constexpr int NAV_MAX_PATH_STEPS = 32;         // Max A* path length
 static constexpr uint16_t NAV_NO_REGION = 0xFFFF;     // Sentinel: no region
 static constexpr int32_t NAV_ATTACH_DISTANCE = 512;
+static constexpr uint8_t NAV_FLAG_PLATFORM = 0x01;
 // ============================================================================
 // Surface type for navigation regions
 // ============================================================================
@@ -35,7 +36,7 @@ enum NavSurfaceType : uint8_t {
 };
 
 // ============================================================================
-// Portal edge — shared edge between two adjacent regions
+// Portal edge: shared edge between two adjacent regions
 // ============================================================================
 struct NavPortal {
     int32_t  ax, az;            // Portal edge start (20.12 XZ)
@@ -46,7 +47,7 @@ struct NavPortal {
 static_assert(sizeof(NavPortal) == 20, "NavPortal must be 20 bytes");
 
 // ============================================================================
-// Nav Region — convex polygon on the XZ plane with floor info
+// Nav Region: convex polygon on the XZ plane with floor info
 // ============================================================================
 struct NavRegion {
     // Convex polygon vertices (XZ, 20.12 fixed-point)
@@ -66,7 +67,8 @@ struct NavRegion {
     // Metadata
     NavSurfaceType surfaceType;  // 1 byte
     uint8_t  roomIndex;          // Interior room (0xFF = exterior)  1 byte
-    uint8_t  pad[2];             // Alignment  2 bytes
+    uint8_t  flags;              // bit 0 = platform (unwalled, walkoff all boundary edges)  1 byte
+    uint8_t  walkoffEdgeMask;    // bit i = edge i to (i+1)%vertCount allows walkoff  1 byte
     // Total: 32 + 32 + 12 + 4 + 4 = 84 bytes
 };
 static_assert(sizeof(NavRegion) == 84, "NavRegion must be 84 bytes");
@@ -91,7 +93,7 @@ struct NavPath {
 };
 
 // ============================================================================
-// NavRegionSystem — manages navigation at runtime
+// NavRegionSystem: manages navigation at runtime
 // ============================================================================
 class NavRegionSystem {
 public:
@@ -148,14 +150,20 @@ public:
     bool isOffNavRegion(int32_t x, int32_t y, int32_t z) const;
 
     /// Clamp an XZ position to stay within a region's polygon boundary.
-    /// Returns the clamped position.
     void clampToRegion(int32_t& x, int32_t& z, uint16_t regionIndex) const;
 
-    // TODO: Implement this
+    /// Clamp to non-walkoff boundary edges only. Walkoff edges are skipped,
+    /// allowing the player to leave the region through those edges.
+    void clampToRegionSelective(int32_t& x, int32_t& z, uint16_t regionIndex) const;
+
+    /// True if the region has the platform flag set.
+    bool isRegionPlatform(uint16_t regionIndex) const;
+
+    /// Return the walkoff edge bitmask for a region.
+    uint8_t getWalkoffEdgeMask(uint16_t regionIndex) const;
+
     bool findPath(uint16_t startRegion, uint16_t endRegion,
                   NavPath& path) const;
-
-    bool isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegion);
 
     private:
     NavDataHeader m_header = {};

--- a/src/navregion.hh
+++ b/src/navregion.hh
@@ -24,7 +24,7 @@ static constexpr int NAV_MAX_VERTS_PER_REGION = 8;   // Max polygon verts
 static constexpr int NAV_MAX_NEIGHBORS = 8;           // Max portal edges per region
 static constexpr int NAV_MAX_PATH_STEPS = 32;         // Max A* path length
 static constexpr uint16_t NAV_NO_REGION = 0xFFFF;     // Sentinel: no region
-static constexpr int32_t NAV_ATTACH_DISTANCE = 1024;
+static constexpr int32_t NAV_ATTACH_DISTANCE = 512;
 // ============================================================================
 // Surface type for navigation regions
 // ============================================================================
@@ -155,7 +155,9 @@ public:
     bool findPath(uint16_t startRegion, uint16_t endRegion,
                   NavPath& path) const;
 
-private:
+    bool isRegionWalled(const uint16_t noWallRegions[], size_t count, uint16_t targetRegionn);
+
+    private:
     NavDataHeader m_header = {};
     const NavRegion* m_regions = nullptr;
     const NavPortal* m_portals = nullptr;

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -549,6 +549,7 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
             }
             else{
                 m_playerNavRegion = newNavRegion;
+                isPlayerNavWalled = m_navRegions.isRegionWalled(noWallRegions, 18, m_playerNavRegion);
             } 
         }
 

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -12,6 +12,7 @@
 
 #include <psyqo/primitives/misc.hh>
 #include <psyqo/trigonometry.hh>
+#include <psyqo/xprintf.h>
 
 #if defined(LOADER_CDROM)
 #include "cdromhelper.hh"
@@ -215,6 +216,7 @@ void psxsplash::SceneManager::InitializeScene(uint8_t* splashpackData, LoadingSc
 #endif
 
     m_playerPosition = sceneSetup.playerStartPosition;
+    m_navRegions.clampToRegion(m_playerPosition.x.value, m_playerPosition.z.value, m_playerNavRegion);
 
     playerRotationX = 0.0_pi;
     playerRotationY = 0.0_pi;
@@ -486,6 +488,9 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
 #endif
 
     uint32_t navmeshStart = gpu.now();
+
+    //m_navRegions.findRegionClosest(m_playerPosition.x.value,m_playerPosition.y.value,m_playerPosition.z.value);
+
     if (!freecam && m_navRegions.isLoaded()) {
         // Apply gravity scaled by dt12 (4096 = 1 frame)
         int32_t gravityDelta = (int32_t)(((int64_t)m_gravityPerFrame * m_dt12) >> 12);
@@ -507,21 +512,31 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
             m_playerPosition.x.value = px;
             m_playerPosition.z.value = pz;
 
+            uint16_t newNavRegion = m_navRegions.findRegionClosest(px,py,pz);
+            floorY = m_navRegions.getFloorY(px,pz,newNavRegion);
             int32_t cameraAtFloor = floorY - m_playerHeight.raw();
 
-            if (m_playerPosition.y.value >= cameraAtFloor) {
+            printf("floorY is %d\n",floorY);
+            //m_playerPosition.y.value >= cameraAtFloor && 
+            if (m_navRegions.isOffNavRegion(px,py,pz) == false) {
                 m_playerPosition.y.value = cameraAtFloor;
                 m_velocityY = 0;
                 m_isGrounded = true;
-            } else {
+                printf("Grounded\n");
+            } else { // FALLING
                 m_isGrounded = false;
+                printf("Falling\n");
             }
-        } else {
+        } else { // JUMPING
             m_playerPosition = oldPlayerPosition;
             m_playerNavRegion = prevRegion;
             m_velocityY = 0;
             m_isGrounded = true;
+            printf("Jumping In Air\n");
         }
+            
+        m_velocityY = 0;
+        //printf("Player Loc: %d  %d  %d\n",m_playerPosition.x,m_playerPosition.y,m_playerPosition.z);
     }
 
 

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -714,6 +714,11 @@ void psxsplash::SceneManager::setPlayerPosition(psyqo::FixedPoint<12> x, psyqo::
     m_playerPosition.x = x;
     m_playerPosition.y = y;
     m_playerPosition.z = z;
+
+    if (m_navRegions.isLoaded()) 
+    {
+        m_playerNavRegion = m_navRegions.findRegionClosest(x.value, y.value, z.value);
+    }
 }
 
 psyqo::Vec3 psxsplash::SceneManager::getPlayerRotation(){

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -12,7 +12,6 @@
 
 #include <psyqo/primitives/misc.hh>
 #include <psyqo/trigonometry.hh>
-#include <psyqo/xprintf.h>
 
 #if defined(LOADER_CDROM)
 #include "cdromhelper.hh"

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -522,54 +522,76 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
 
     uint32_t navmeshStart = gpu.now();
 
-    //m_navRegions.findRegionClosest(m_playerPosition.x.value,m_playerPosition.y.value,m_playerPosition.z.value);
-
     if (!freecam && m_navRegions.isLoaded()) {
         // Apply gravity scaled by dt12 (4096 = 1 frame)
         int32_t gravityDelta = (int32_t)(((int64_t)m_gravityPerFrame * m_dt12) >> 12);
         m_velocityY += gravityDelta;
+        
+        // Downward velocity cap
+        if(m_velocityY >= m_downwardVelocityCap)
+        {
+            m_velocityY = m_downwardVelocityCap;
+        }
 
         // Apply vertical velocity to position, scaled by dt12
         int32_t posYDelta = (int32_t)(((int64_t)m_velocityY * m_dt12) >> 12);
         m_playerPosition.y.value += posYDelta;
 
-        // Resolve position via nav regions
-        uint16_t prevRegion = m_playerNavRegion;
         int32_t px = m_playerPosition.x.value;
         int32_t py = m_playerPosition.y.value;
         int32_t pz = m_playerPosition.z.value;
-        int32_t floorY = m_navRegions.resolvePosition(
-            px, py, pz, m_playerNavRegion);
 
-        if (m_playerNavRegion != NAV_NO_REGION) {
-            m_playerPosition.x.value = px;
-            m_playerPosition.z.value = pz;
+        uint16_t newNavRegion = m_navRegions.findRegionClosest(px,py,pz);
 
-            uint16_t newNavRegion = m_navRegions.findRegionClosest(px,py,pz);
-            floorY = m_navRegions.getFloorY(px,pz,newNavRegion);
-            int32_t cameraAtFloor = floorY - m_playerHeight.raw();
+        bool isPlayerNavWalled = m_navRegions.isRegionWalled(noWallRegions, 18, m_playerNavRegion);
+        
+        // Not in original region
+        if(m_playerNavRegion != newNavRegion){
 
-            printf("floorY is %d\n",floorY);
-            //m_playerPosition.y.value >= cameraAtFloor && 
-            if (m_navRegions.isOffNavRegion(px,py,pz) == false) {
-                m_playerPosition.y.value = cameraAtFloor;
-                m_velocityY = 0;
-                m_isGrounded = true;
-                printf("Grounded\n");
-            } else { // FALLING
-                m_isGrounded = false;
-                printf("Falling\n");
+            // Valid Region to No Region
+            if(m_playerNavRegion != NAV_NO_REGION && newNavRegion == NAV_NO_REGION){
+                if(isPlayerNavWalled == false){
+                   m_isGrounded = false; 
+                }
             }
-        } else { // JUMPING
-            m_playerPosition = oldPlayerPosition;
-            m_playerNavRegion = prevRegion;
-            m_velocityY = 0;
-            m_isGrounded = true;
-            printf("Jumping In Air\n");
+            else{
+                m_playerNavRegion = newNavRegion;
+            } 
         }
+
+        // Is there a valid region?
+        if(m_playerNavRegion != NAV_NO_REGION){
+            int32_t floorY = m_navRegions.getFloorY(px,pz,m_playerNavRegion);
+            int32_t cameraAtFloor = floorY - m_playerHeight.raw();
             
-        m_velocityY = 0;
-        //printf("Player Loc: %d  %d  %d\n",m_playerPosition.x,m_playerPosition.y,m_playerPosition.z);
+            // Lock down the Y if grounded
+            if(m_isGrounded){
+                if(m_playerPosition.y.value > cameraAtFloor){
+                    m_playerPosition.y.value = cameraAtFloor;
+                    m_velocityY = 0;
+                } 
+            }
+            // Handles falling / jumping on to a region
+            else if(m_playerPosition.y.value > floorY - m_playerHeight.raw()) {
+                
+                m_isGrounded = true;
+            }
+
+            // Let the player fall for a bit before disabling jump 
+            if(m_playerPosition.y.value > floorY + m_playerHeight.raw() + m_coyoteTimeDistance)
+            {
+                m_isGrounded = false;
+                m_playerNavRegion = NAV_NO_REGION;
+            }
+        }
+        else // No Nav Region
+        {
+            m_isGrounded = false;
+        }
+        
+        if(isPlayerNavWalled){
+            m_navRegions.clampToRegion(m_playerPosition.x.value, m_playerPosition.z.value, m_playerNavRegion);
+        }
     }
 
 

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -237,7 +237,6 @@ void psxsplash::SceneManager::InitializeScene(uint8_t* splashpackData, LoadingSc
 #endif
 
     m_playerPosition = sceneSetup.playerStartPosition;
-    m_navRegions.clampToRegion(m_playerPosition.x.value, m_playerPosition.z.value, m_playerNavRegion);
 
     playerRotationX = 0.0_pi;
     playerRotationY = 0.0_pi;

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -535,20 +535,24 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
 
         uint16_t newNavRegion = m_navRegions.findRegionClosest(px,py,pz);
 
-        bool isPlayerNavWalled = m_navRegions.isRegionWalled(noWallRegions, 18, m_playerNavRegion);
+        bool isPlatform = m_navRegions.isRegionPlatform(m_playerNavRegion);
+        uint8_t walkoffMask = m_navRegions.getWalkoffEdgeMask(m_playerNavRegion);
+        bool canWalkOff = isPlatform || (walkoffMask != 0);
         
         // Not in original region
         if(m_playerNavRegion != newNavRegion){
 
             // Valid Region to No Region
             if(m_playerNavRegion != NAV_NO_REGION && newNavRegion == NAV_NO_REGION){
-                if(isPlayerNavWalled == false){
+                if(canWalkOff){
                    m_isGrounded = false; 
                 }
             }
             else{
                 m_playerNavRegion = newNavRegion;
-                isPlayerNavWalled = m_navRegions.isRegionWalled(noWallRegions, 18, m_playerNavRegion);
+                isPlatform = m_navRegions.isRegionPlatform(m_playerNavRegion);
+                walkoffMask = m_navRegions.getWalkoffEdgeMask(m_playerNavRegion);
+                canWalkOff = isPlatform || (walkoffMask != 0);
             } 
         }
 
@@ -582,7 +586,12 @@ void psxsplash::SceneManager::GameTick(psyqo::GPU &gpu) {
             m_isGrounded = false;
         }
         
-        if(isPlayerNavWalled){
+        // Clamp movement to region boundaries where walls exist
+        if (isPlatform) {
+            // Platform regions have no boundary clamping
+        } else if (walkoffMask != 0) {
+            m_navRegions.clampToRegionSelective(m_playerPosition.x.value, m_playerPosition.z.value, m_playerNavRegion);
+        } else {
             m_navRegions.clampToRegion(m_playerPosition.x.value, m_playerPosition.z.value, m_playerNavRegion);
         }
     }

--- a/src/scenemanager.hh
+++ b/src/scenemanager.hh
@@ -218,5 +218,14 @@ class SceneManager {
     void processEnableDisableEvents();
     void clearScene();  // Deallocate current scene objects
     void shrinkBuffer(); // Free pixel/audio bulk data after VRAM/SPU uploads
+
+    static constexpr uint16_t noWallRegions[18] = { 
+        7,8,9,10,11, 
+        12,16,17,18,19,
+        22,23,24,25,26,
+        27,28,29};
+    
+    const uint16_t m_coyoteTimeDistance = 24; // How far you can fall and still jump
+    const uint16_t m_downwardVelocityCap = 32; // Limit downward velocity
 };
 }  // namespace psxsplash

--- a/src/scenemanager.hh
+++ b/src/scenemanager.hh
@@ -217,12 +217,6 @@ class SceneManager {
     void processEnableDisableEvents();
     void clearScene();  // Deallocate current scene objects
 
-    static constexpr uint16_t noWallRegions[18] = { 
-        7,8,9,10,11, 
-        12,16,17,18,19,
-        22,23,24,25,26,
-        27,28,29};
-    
     const uint16_t m_coyoteTimeDistance = 24; // How far you can fall and still jump
     const uint16_t m_downwardVelocityCap = 32; // Limit downward velocity
 


### PR DESCRIPTION
### Changes
- Allowed certain regions to have no walls / restrictions on leaving the region. Normal regions will detect you trying to go off the nav region and will clamp you back on to it.

### Untested
- Haven't tested portal / rooms.
- No longer calling resolvePosition.  So can remove it entirely if there is nothing useful left in there. 

### Settings during my tests
Radius: 0.1
Walk Speed: 12
Jump Height: 0.2
Gravity 3 

### Requested
I've been manually editing an array whenever the region numbers changes in the editor. So a way to set and transfer that data over is probably the most important change needed.

Either via a new component or additional options on the existing components (Psx Object Exporter / Psx Player)
- Tell the inspector that some/all of the regions on this mesh are considered no wall/platform. 
- Either automatically create the noWallRegion array or store the data inside the NavRegion struct itself. isRegionWalled is the function I use to check.
- Ability to change/override the gap between the nav region and the edge of the mesh. For platforms I want the nav region to fully cover it. 
- Set these variables with the inspector. rotSpeed, m_coyoteTimeDistance, m_downwardVelocityCap, 

#### Demo Video (Same video as what I posted in discord)
https://youtu.be/sTrgmagwxCA