### PR TITLE
Add CD-DA support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ PSX.Dev-README.md
 .editorconfig
 .clang-format
 compile_commands.json
+.idea
 LICENSEE.DAT
 *.iso
 system.cnf

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ src/animation.cpp \
 src/uisystem.cpp \
 src/loadingscreen.cpp \
 src/memoverlay.cpp \
+src/musicmanager.cpp \
 src/skinmesh.cpp \
 src/loadbuffer_patch.cpp
 
@@ -70,3 +71,4 @@ LIBRARIES := $(subst liblua.a,liblua-noparser.a,$(LIBRARIES))
 # metatable init and redirect it to pre-compiled bytecode.
 LDFLAGS += -Wl,--wrap=luaL_loadbufferx
 endif
+

--- a/src/fileloader_cdrom.hh
+++ b/src/fileloader_cdrom.hh
@@ -212,6 +212,8 @@ class FileLoaderCDRom final : public FileLoader {
     /** Stash the GPU pointer so LoadFileSync can spin on pumpCallbacks. */
     void setGPU(psyqo::GPU* gpu) { m_gpu = gpu; }
 
+    psyqo::CDRomDevice* getCDRomDevice() { return &m_cdrom; }
+
   private:
     psyqo::CDRomDevice m_cdrom;
     psyqo::ISO9660Parser m_isoParser;

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -229,6 +229,18 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
     
     L.push(Audio_StopAll);
     L.setField(-2, "StopAll");
+
+    L.push(Audio_PlayCDDA);
+    L.setField(-2, "PlayCDDA");
+
+    L.push(Audio_ResumeCDDA);
+    L.setField(-2, "ResumeCDDA");
+
+    L.push(Audio_PauseCDDA);
+    L.setField(-2, "PauseCDDA");
+
+    L.push(Audio_StopCDDA);
+    L.setField(-2, "StopCDDA");
     
     L.setGlobal("Audio");
     
@@ -1559,6 +1571,34 @@ int LuaAPI::Audio_StopAll(lua_State* L) {
     psyqo::Lua lua(L);
     if (!s_sceneManager) return 0;
     s_sceneManager->getAudio().stopAll();
+    return 0;
+}
+
+int LuaAPI::Audio_PlayCDDA(lua_State *L) {
+    psyqo::Lua lua(L);
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().playCDDATrack(static_cast<int>(lua.toNumber(1)));
+    return 0;
+}
+
+int LuaAPI::Audio_ResumeCDDA(lua_State *L) {
+    psyqo::Lua lua(L);
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().resumeCDDA();
+    return 0;
+}
+
+int LuaAPI::Audio_PauseCDDA(lua_State *L) {
+    psyqo::Lua lua(L);
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().pauseCDDA();
+    return 0;
+}
+
+int LuaAPI::Audio_StopCDDA(lua_State *L) {
+    psyqo::Lua lua(L);
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().stopCDDA();
     return 0;
 }
 

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -241,6 +241,12 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
 
     L.push(Audio_StopCDDA);
     L.setField(-2, "StopCDDA");
+
+    L.push(Audio_TellCDDA);
+    L.setField(-2, "TellCDDA");
+
+    L.push(Audio_SetCDDAVolume);
+    L.setField(-2, "SetCDDAVolume");
     
     L.setGlobal("Audio");
     
@@ -1599,6 +1605,19 @@ int LuaAPI::Audio_StopCDDA(lua_State *L) {
     psyqo::Lua lua(L);
     if (!s_sceneManager) return 0;
     s_sceneManager->getMusic().stopCDDA();
+    return 0;
+}
+
+int LuaAPI::Audio_TellCDDA(lua_State *L) {
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().tellCDDA(L);
+    return 0;
+}
+
+int LuaAPI::Audio_SetCDDAVolume(lua_State *L) {
+    psyqo::Lua lua(L);
+    if (!s_sceneManager) return 0;
+    s_sceneManager->getMusic().setCDDAVolume(static_cast<int>(lua.toNumber(1)), static_cast<int>(lua.toNumber(2)));
     return 0;
 }
 

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -236,6 +236,12 @@ private:
 
     // Audio.StopCDDA()
     static int Audio_StopCDDA(lua_State* L);
+
+    // Audio.TellCDDA()
+    static int Audio_TellCDDA(lua_State* L);
+
+    // Audio.SetCDDAVolume()
+    static int Audio_SetCDDAVolume(lua_State* L);
     
     // ========================================================================
     // DEBUG API - Development helpers

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -224,6 +224,18 @@ private:
     
     // Audio.StopAll()
     static int Audio_StopAll(lua_State* L);
+
+    // Audio.PlayCDDA(trackNo)
+    static int Audio_PlayCDDA(lua_State* L);
+
+    // Audio.ResumeCDDA()
+    static int Audio_ResumeCDDA(lua_State* L);
+
+    // Audio.PauseCDDA()
+    static int Audio_PauseCDDA(lua_State* L);
+
+    // Audio.StopCDDA()
+    static int Audio_StopCDDA(lua_State* L);
     
     // ========================================================================
     // DEBUG API - Development helpers

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -14,6 +14,7 @@ MusicManager::MusicManager() {
 }
 
 void MusicManager::playCDDATrack(int trackNum) {
+#ifdef LOADER_CDROM
     CDRomHelper::WakeDrive();
 
     if (!(SPU_CTRL & 0x1)) {
@@ -25,42 +26,46 @@ void MusicManager::playCDDATrack(int trackNum) {
     mCDRomDevice->playCDDATrack(trackNum,
         [this, trackNum](bool success) {
             mPlayingCDDA = success;
-            ramsyscall_printf("CDDA playback success %d\n", success);
             if (mPlayingCDDA)
                 mCurrentCDDATrack = trackNum;
     });
+#endif // LOADER_CDROM
 }
 
 void MusicManager::resumeCDDA() {
-    ramsyscall_printf("resume\n");
+#ifdef LOADER_CDROM
     if (mCurrentCDDATrack >= 0 && !mPlayingCDDA) {
         mCDRomDevice->resumeCDDA([this](bool success) {
             if (success)
                 mPlayingCDDA = true;
         });
     }
+#endif // LOADER_CDROM
 }
 
 void MusicManager::pauseCDDA() {
-    ramsyscall_printf("pause\n");
+#ifdef LOADER_CDROM
     if (mCurrentCDDATrack >= 0 && mPlayingCDDA) {
         mCDRomDevice->pauseCDDA();
         mPlayingCDDA = false;
     }
+#endif // LOADER_CDROM
 }
 
 void MusicManager::stopCDDA() {
+#ifdef LOADER_CDROM
     mCDRomDevice->stopCDDA();
     mCurrentCDDATrack = -1;
     mPlayingCDDA = false;
+#endif // LOADER_CDROM
 }
 
 void MusicManager::tellCDDA(lua_State* L) {
+#ifdef LOADER_CDROM
     if (!L) return;
     psyqo::Lua luaState(L);
     int cb = LUA_NOREF;
     if (luaState.isFunction(-1)) {
-        ramsyscall_printf("function\n");
         cb = luaState.ref();
     }
     else {
@@ -68,7 +73,6 @@ void MusicManager::tellCDDA(lua_State* L) {
     }
 
     mCDRomDevice->getPlaybackLocation([L, cb](psyqo::CDRomDevice::PlaybackLocation* location) {
-        ramsyscall_printf("cb %d\n", cb);
         if (location && cb != LUA_NOREF) {
             psyqo::FixedPoint<12> loc((location->relative.m * 60) + location->relative.s,location->relative.f * 54);
 
@@ -85,9 +89,12 @@ void MusicManager::tellCDDA(lua_State* L) {
             }
         }
     });
+#endif // LOADER_CDROM
 }
 
 void MusicManager::setCDDAVolume(int left, int right) {
+#ifdef LOADER_CDROM
     mCDRomDevice->setVolume(left, 0, 0, right);
+#endif // LOADER_CDROM
 }
 } // namespace psxsplash

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -1,0 +1,55 @@
+#include "musicmanager.hh"
+#include "cdromhelper.hh"
+
+#include <common/syscalls/syscalls.h>
+#include <psyqo/spu.hh>
+
+#include <common/hardware/spu.h>
+
+namespace psxsplash {
+MusicManager::MusicManager() {
+}
+
+void MusicManager::playCDDATrack(int trackNum) {
+    //CDRomHelper::WakeDrive();
+
+    if (!(SPU_CTRL & 0x1)) {
+        SPU_CTRL |= 0x1;
+        SPU_VOL_CD_LEFT = 0x7fff;
+        SPU_VOL_CD_RIGHT = 0x7fff;
+    }
+
+    mCDRomDevice->playCDDATrack(trackNum,
+        [this, trackNum](bool success) {
+            mPlayingCDDA = success;
+            ramsyscall_printf("CDDA playback success %d\n", success);
+            if (mPlayingCDDA)
+                mCurrentCDDATrack = trackNum;
+    });
+}
+
+void MusicManager::resumeCDDA() {
+    ramsyscall_printf("resume\n");
+    if (mCurrentCDDATrack >= 0 && !mPlayingCDDA) {
+        mCDRomDevice->resumeCDDA([this](bool success) {
+            if (success)
+                mPlayingCDDA = true;
+        });
+    }
+}
+
+void MusicManager::pauseCDDA() {
+    ramsyscall_printf("pause\n");
+    if (mCurrentCDDATrack >= 0 && mPlayingCDDA) {
+        mCDRomDevice->pauseCDDA();
+        mPlayingCDDA = false;
+    }
+}
+
+void MusicManager::stopCDDA() {
+    mCDRomDevice->stopCDDA();
+    mCurrentCDDATrack = -1;
+    mPlayingCDDA = false;
+}
+
+} // namespace psxsplash

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -2,16 +2,19 @@
 #include "cdromhelper.hh"
 
 #include <common/syscalls/syscalls.h>
+#include <psyqo/fixed-point.hh>
 #include <psyqo/spu.hh>
 
 #include <common/hardware/spu.h>
+
+#include "lstate.h"
 
 namespace psxsplash {
 MusicManager::MusicManager() {
 }
 
 void MusicManager::playCDDATrack(int trackNum) {
-    //CDRomHelper::WakeDrive();
+    CDRomHelper::WakeDrive();
 
     if (!(SPU_CTRL & 0x1)) {
         SPU_CTRL |= 0x1;
@@ -52,4 +55,39 @@ void MusicManager::stopCDDA() {
     mPlayingCDDA = false;
 }
 
+void MusicManager::tellCDDA(lua_State* L) {
+    if (!L) return;
+    psyqo::Lua luaState(L);
+    int cb = LUA_NOREF;
+    if (luaState.isFunction(-1)) {
+        ramsyscall_printf("function\n");
+        cb = luaState.ref();
+    }
+    else {
+        luaState.pop();
+    }
+
+    mCDRomDevice->getPlaybackLocation([L, cb](psyqo::CDRomDevice::PlaybackLocation* location) {
+        ramsyscall_printf("cb %d\n", cb);
+        if (location && cb != LUA_NOREF) {
+            psyqo::FixedPoint<12> loc((location->relative.m * 60) + location->relative.s,location->relative.f * 54);
+
+            psyqo::Lua luaState(L);
+            luaState.rawGetI(LUA_REGISTRYINDEX, cb);
+            if (luaState.isFunction(-1)) {
+                luaState.push(loc);
+                if (luaState.pcall(1, 0) != LUA_OK) {
+                    luaState.pop();
+                    luaState.pop();
+                }
+            } else {
+                luaState.pop();
+            }
+        }
+    });
+}
+
+void MusicManager::setCDDAVolume(int left, int right) {
+    mCDRomDevice->setVolume(left, 0, 0, right);
+}
 } // namespace psxsplash

--- a/src/musicmanager.hh
+++ b/src/musicmanager.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <psyqo/cdrom-device.hh>
+#include <psyqo-lua/lua.hh>
 
 namespace psxsplash {
 
@@ -8,19 +9,16 @@ class MusicManager {
 public:
     MusicManager();
 
-    // Play a CD-DA track
+    // CD-DA functions
     void playCDDATrack(int trackNum);
     void resumeCDDA();
     void pauseCDDA();
     void stopCDDA();
+    void tellCDDA(lua_State* L);
+    void setCDDAVolume(int left, int right);
+    bool isPlayingCDDA() const { return mPlayingCDDA; }
 
     void setCDRomDevice(psyqo::CDRomDevice* device) { mCDRomDevice = device; }
-
-    struct CDDATrackReport {
-        unsigned int position;
-        unsigned int length;
-        int trackNumber;
-    };
 private:
     psyqo::CDRomDevice* mCDRomDevice = nullptr;
     bool mPlayingCDDA = false;

--- a/src/musicmanager.hh
+++ b/src/musicmanager.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <psyqo/cdrom-device.hh>
+
+namespace psxsplash {
+
+class MusicManager {
+public:
+    MusicManager();
+
+    // Play a CD-DA track
+    void playCDDATrack(int trackNum);
+    void resumeCDDA();
+    void pauseCDDA();
+    void stopCDDA();
+
+    void setCDRomDevice(psyqo::CDRomDevice* device) { mCDRomDevice = device; }
+
+    struct CDDATrackReport {
+        unsigned int position;
+        unsigned int length;
+        int trackNumber;
+    };
+private:
+    psyqo::CDRomDevice* mCDRomDevice = nullptr;
+    bool mPlayingCDDA = false;
+    int mCurrentCDDATrack = -1;
+};
+
+} // namespace psxsplash

--- a/src/scenemanager.cpp
+++ b/src/scenemanager.cpp
@@ -15,6 +15,7 @@
 
 #if defined(LOADER_CDROM)
 #include "cdromhelper.hh"
+#include "fileloader_cdrom.hh"
 #endif
 
 #include "lua.h"
@@ -42,7 +43,12 @@ void psxsplash::SceneManager::InitializeScene(uint8_t* splashpackData, LoadingSc
     
     // Initialize audio system
     m_audio.init();
-    
+
+#ifdef LOADER_CDROM
+    m_music.setCDRomDevice(static_cast<psxsplash::FileLoaderCDRom&>(
+        psxsplash::FileLoader::Get()).getCDRomDevice());
+#endif
+
     // Register the Lua API
     LuaAPI::RegisterAll(L.getState(), this, &m_cutscenePlayer, &m_animationPlayer, &m_uiSystem);
 

--- a/src/scenemanager.hh
+++ b/src/scenemanager.hh
@@ -15,6 +15,7 @@
 #include "splashpack.hh"
 #include "navregion.hh"
 #include "audiomanager.hh"
+#include "musicmanager.hh"
 #include "interactable.hh"
 #include "luaapi.hh"
 #include "fileloader.hh"
@@ -89,6 +90,7 @@ class SceneManager {
     Camera& getCamera() { return m_currentCamera; }
     Lua& getLua() { return L; }
     AudioManager& getAudio() { return m_audio; }
+    MusicManager& getMusic() { return m_music; }
 
     // Controls enable/disable (Lua-driven)
     void setControlsEnabled(bool enabled) { m_controlsEnabled = enabled; }
@@ -162,6 +164,7 @@ class SceneManager {
     
     // Audio system
     AudioManager m_audio;
+    MusicManager m_music;
     
     // Cutscene playback
     Cutscene m_cutscenes[MAX_CUTSCENES];


### PR DESCRIPTION
Added CD-DA playback support using lua functions, as well as some other useful functions:

Audio.PlayCDDA(track) - Start's playback of the given track
Audio.PauseCDDA() - Pauses the current track
Audio.ResumeCDDA() - Resumes the current track
Audio.StopCDDA() - Stops the current track
Audio.TellCDDA() - Reports the current playhead position in seconds (fixed point)    NOTE: This is know to crash when spammed, so should be used infrequently for now
Audio.SetCDDAVolume(left, right) - Set's the L & R volume of CD music   NOTE: Will also affect XA, so this may need renaming in the future 