### PR TITLE
Fixed Bug with Debug.Log

### DIFF
--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -260,7 +260,7 @@ void psxsplash::Lua::Init() {
                 if (L.isFixedPoint(i)) {
                     auto fp = L.toFixedPoint(i);
                     int32_t raw = fp.raw();
-                    int integer = raw >> 12;
+                    int integer = raw / 4096;
                     unsigned fraction = (raw < 0 ? -raw : raw) & 0xfff;
                     if (fraction == 0) {
                         len += snprintf(buf + len, sizeof(buf) - len, "%d", integer);


### PR DESCRIPTION
### Changes
Negative numbers were being rounded up when displaying it using Debug.Log. The under lying data would be representing -0.5 but the log would display it as -1.5

When converting a fixed point number to a string I changed it to divide by 4096 instead of bit shifting 12. This then produced the correct results from the test script.

### Tests
```
-- Test script for displaying fixed point numbers
local one = FixedPoint.new(1)
local half = one / 2              -- 0.5
local quarter = one / 4           -- 0.25
local threeQuarters = one * 3 / 4 -- 0.75
local negOne = FixedPoint.new(-1)
local negOneMultiplied = FixedPoint.new(1) * -1
local negOneSubtracted = FixedPoint.new(0) - 1

local fp1 = FixedPoint.new(1)/2 - FixedPoint.new(2) -- Wrong -2.500
local fp2 = -FixedPoint.new(1)/2 -- Wrong -1.500
local fp3 = FixedPoint.new(1) - FixedPoint.new(1) -- Correct 0
local fp4 = FixedPoint.new(1)/2 - FixedPoint.new(1)/4 -- Correct 0.250
local fp5 = FixedPoint.new(0) - FixedPoint.new(1)/4 -- Wrong -1.250
local fp6 = -FixedPoint.new(1)/4 -- Wrong -1.250
local fp7 = FixedPoint.new(1) - FixedPoint.new(3) -- Correct -2


function onCreate(self)
        Debug.Log("One is " .. one)
        Debug.Log("half is" .. half)
        Debug.Log("quarter is " .. quarter)
        Debug.Log("threeQuarters is " .. threeQuarters)
        Debug.Log(" --- Neg Start --- ")
        Debug.Log("Negative One " .. negOne)
        Debug.Log("Negative One Multiplied " .. negOneMultiplied)
        Debug.Log("Negative One Subtracted " .. negOneSubtracted)

        Debug.Log("\n --- Fp Start --- ")
        Debug.Log("fp1 " .. fp1)
        Debug.Log("fp2 " .. fp2)
        Debug.Log("fp3 " .. fp3)
        Debug.Log("fp4 " .. fp4)
        Debug.Log("fp5 " .. fp5)
        Debug.Log("fp6 " .. fp6)
        Debug.Log("fp7 " .. fp7)
end
```