### PR TITLE
Added Convert.IntToFp and Convert.FpToInt

### DIFF
--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -255,12 +255,11 @@ void psxsplash::Lua::Init() {
             // Convert both operands to strings and concatenate
             char buf[64];
             int len = 0;
-
             for (int i = 1; i <= 2; i++) {
                 if (L.isFixedPoint(i)) {
                     auto fp = L.toFixedPoint(i);
                     int32_t raw = fp.raw();
-                    int integer = raw >> 12;
+                    int integer = raw / 4096;
                     unsigned fraction = (raw < 0 ? -raw : raw) & 0xfff;
                     if (fraction == 0) {
                         len += snprintf(buf + len, sizeof(buf) - len, "%d", integer);

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -249,6 +249,19 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
     L.setGlobal("Debug");
     
     // ========================================================================
+    // CONVERT API
+    // ========================================================================
+    L.newTable();  // Convert table
+    
+    L.push(Convert_IntToFp);
+    L.setField(-2, "IntToFp");
+
+    L.push(Convert_FpToInt);
+    L.setField(-2, "FpToInt");
+    
+    L.setGlobal("Convert");
+
+    // ========================================================================
     // MATH API
     // ========================================================================
     L.newTable();  // PSXMath table (avoid conflict with Lua's math)
@@ -1601,6 +1614,38 @@ int LuaAPI::Debug_DrawBox(lua_State* L) {
     // TODO: Queue 12 LINE_G2 primitives (box wireframe) through Renderer
     return 0;
 }
+
+// ============================================================================
+// FP API IMPLEMENTATION
+// ============================================================================
+
+int LuaAPI::Convert_IntToFp(lua_State* L) {
+    psyqo::Lua lua(L);
+    
+    if (!lua.isNumber(1)) {
+        return 0;
+    }
+
+    psyqo::FixedPoint<12> numberFp; 
+    numberFp = psyqo::FixedPoint<12>(static_cast<int32_t>(lua.toNumber(1)), psyqo::FixedPoint<12>::RAW);
+    
+    lua.push(numberFp);
+    return 1;
+}
+
+int LuaAPI::Convert_FpToInt(lua_State* L) {
+    psyqo::Lua lua(L);
+    
+    if (!lua.isFixedPoint(1)) { 
+        return 0;
+    }
+
+    uint32_t numberInt = lua.toFixedPoint(1).raw();
+
+    lua.pushNumber(numberInt);
+    return 1;
+}
+
 
 // ============================================================================
 // MATH API IMPLEMENTATION

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -239,6 +239,16 @@ private:
     static int Debug_DrawBox(lua_State* L);
     
     // ========================================================================
+    // CONVERT API - Extra functions for working with fixed point numbers 
+    // ========================================================================
+
+    // Convert.IntToFp(intValue) - Returns fp value
+    static int Convert_IntToFp(lua_State* L);
+
+    // Convert.FpToInt(fpValue) - Returns int value
+    static int Convert_FpToInt(lua_State* L);
+
+    // ========================================================================
     // MATH API - Additional math functions
     // ========================================================================
     


### PR DESCRIPTION
### Changes
 Just a couple helper functions for working with fixed point numbers.

### Test Script Output
 ----- To Int Tests -----
one is 1 raw int is 4096
half is 0.500 raw int is 2048
negQuarter is -0.250 raw int is -1024
 ----- To Fixed Point Tests -----
a (4096) is 1
b (2048) is 0.500
c (-1024) is -0.250

### Test Script
```
local one = FixedPoint.new(1)
local half = one / 2              
local negQuarter = -one / 4       

function onCreate(self)
        Debug.Log("\n\n ----- To Int Tests -----")
        
        local oneInt = Convert.FpToInt(one)
        Debug.Log("one is " .. one .. " raw int is " .. oneInt)

        local halfInt = Convert.FpToInt(half)
        Debug.Log("half is " .. half .. " raw int is " .. halfInt )

        local negQuarterInt = Convert.FpToInt(negQuarter)
        Debug.Log("negQuarter is " .. negQuarter .. " raw int is " .. negQuarterInt )

        Debug.Log("\n ----- To Fixed Point Tests -----")
        
        local a = Convert.IntToFp(4096);
        local b = Convert.IntToFp(2048);
        local c = Convert.IntToFp(-1024);

        Debug.Log("a (4096) is " .. a)
        Debug.Log("b (2048) is " .. b)
        Debug.Log("c (-1024) is " .. c)
end
```
