### PR TITLE
UV Offsetting and Animation

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -276,6 +276,16 @@ void AnimationPlayer::applyTrack(CutsceneTrack& track, uint16_t frame, uint16_t 
             break;
         }
 
+        case TrackType::ObjectUVOffset: {
+            if (!track.target) return;
+            psxsplash::lerpKeyframesSub(track.keyframes, track.keyframeCount, frame, subFrame, track.initialValues, out);
+            uint8_t u = (out[0] < 0) ? 0 : ((out[0] > 255) ? 255 : (uint8_t)out[0]);
+            uint8_t v = (out[1] < 0) ? 0 : ((out[1] > 255) ? 255 : (uint8_t)out[1]);
+
+            track.target->uvOffset = { u, v };
+            break;
+        }
+
         case TrackType::UICanvasVisible: {
             if (!m_uiSystem) return;
             CutsceneKeyframe* kf = track.keyframes;

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -186,6 +186,12 @@ void AnimationPlayer::captureInitialValues(Animation* anim) {
                     track.initialValues[0] = m_uiSystem->isElementVisible(track.uiHandle) ? 1 : 0;
                 }
                 break;
+            case TrackType::ObjectUVOffset:
+                if (track.target) {
+                    track.initialValues[0] = track.target->uvOffset.u;
+                    track.initialValues[1] = track.target->uvOffset.v;
+                }
+                break;
             case TrackType::UIProgress:
                 if (m_uiSystem) {
                     track.initialValues[0] = m_uiSystem->getProgress(track.uiHandle);

--- a/src/cutscene.cpp
+++ b/src/cutscene.cpp
@@ -83,6 +83,13 @@ bool CutscenePlayer::play(const char* name, bool loop) {
                             track.initialValues[0] = track.target->isActive() ? 1 : 0;
                         }
                         break;
+                    case TrackType::ObjectUVOffset: {
+                        if (track.target) {
+                            track.initialValues[0] = track.target->uvOffset.u;
+                            track.initialValues[1] = track.target->uvOffset.v;
+                        }
+                        break;
+                    }
                     case TrackType::UICanvasVisible:
                         if (m_uiSystem) {
                             track.initialValues[0] = m_uiSystem->isCanvasVisible(track.uiHandle) ? 1 : 0;

--- a/src/cutscene.cpp
+++ b/src/cutscene.cpp
@@ -317,6 +317,16 @@ void CutscenePlayer::applyTrack(CutsceneTrack& track) {
             break;
         }
 
+        case TrackType::ObjectUVOffset: {
+            if (!track.target) return;
+            psxsplash::lerpKeyframesSub(track.keyframes, track.keyframeCount, m_frame, m_subFrame, track.initialValues, out);
+            uint8_t u = (out[0] < 0) ? 0 : ((out[0] > 255) ? 255 : (uint8_t)out[0]);
+            uint8_t v = (out[1] < 0) ? 0 : ((out[1] > 255) ? 255 : (uint8_t)out[1]);
+
+            track.target->uvOffset = { u, v };
+            break;
+        }
+
         // ── UI track types ──
 
         case TrackType::UICanvasVisible: {

--- a/src/cutscene.hh
+++ b/src/cutscene.hh
@@ -40,6 +40,7 @@ enum class TrackType : uint8_t {
     CameraH         = 10,
     RumbleSmall     = 11,
     RumbleLarge     = 12,
+    ObjectUVOffset  = 13,
 };
 
 /// Helper: true if a TrackType drives a UI property (canvas or element).

--- a/src/gameobject.hh
+++ b/src/gameobject.hh
@@ -48,7 +48,7 @@ class GameObject final {
     
     // Component indices (0xFFFF = no component)
     uint16_t interactableIndex;
-    uint16_t _reserved0;       // Was healthIndex (legacy, kept for binary layout)
+    psyqo::PrimPieces::UVCoords uvOffset;       // Was healthIndex (legacy)
     // Runtime-only: Lua event bitmask (set during RegisterGameObject)
     // In the splashpack binary these 4 bytes are _reserved1 + _reserved2 (zeros).
     uint32_t eventMask;

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -817,7 +817,7 @@ int LuaAPI::Entity_SetUVOffset(lua_State *L) {
     auto go = lua.toUserdata<GameObject>(-1);
     lua.pop();
 
-    if (!go) return 0;
+    if (!go || !lua.isNumber(2) || !lua.isNumber(3)) return 0;
 
     uint8_t u = static_cast<uint8_t>(lua.toNumber(2));
     uint8_t v = static_cast<uint8_t>(lua.toNumber(3));

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -86,6 +86,9 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
     
     L.push(Entity_ForEach);
     L.setField(-2, "ForEach");
+
+    L.push(Entity_SetUVOffset);
+    L.setField(-2, "SetUVOffset");
     
     L.setGlobal("Entity");
     
@@ -802,6 +805,24 @@ int LuaAPI::Entity_ForEach(lua_State* L) {
         }
     }
     
+    return 0;
+}
+
+int LuaAPI::Entity_SetUVOffset(lua_State *L) {
+    psyqo::Lua lua(L);
+
+    if (!lua.isTable(1)) return 0;
+
+    lua.getField(1, "__cpp_ptr");
+    auto go = lua.toUserdata<GameObject>(-1);
+    lua.pop();
+
+    if (!go) return 0;
+
+    uint8_t u = static_cast<uint8_t>(lua.toNumber(2));
+    uint8_t v = static_cast<uint8_t>(lua.toNumber(3));
+    go->uvOffset = { u, v };
+
     return 0;
 }
 

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -90,7 +90,7 @@ private:
     // Calls callback(object, index) for each active game object
     static int Entity_ForEach(lua_State* L);
 
-    // Entity.SetUVOffset(x, y)
+    // Entity.SetUVOffset(object, u, v)
     static int Entity_SetUVOffset(lua_State* L);
     
     // ========================================================================

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -89,6 +89,9 @@ private:
     // Entity.ForEach(callback) -> nil
     // Calls callback(object, index) for each active game object
     static int Entity_ForEach(lua_State* L);
+
+    // Entity.SetUVOffset(x, y)
+    static int Entity_SetUVOffset(lua_State* L);
     
     // ========================================================================
     // VEC3 API - Vector math

--- a/src/mesh.hh
+++ b/src/mesh.hh
@@ -8,6 +8,9 @@ namespace psxsplash {
   // Sentinel value for untextured (vertex-color-only) triangles
   static constexpr uint16_t UNTEXTURED_TPAGE = 0xFFFF;
 
+  // Flags for tris, was going to use Utilities::BitField but I couldn't get it to be in 2 bytes
+  static constexpr uint16_t ANIM_FLAG = 0x1;
+
   class Tri final {
     public:
       psyqo::GTE::PackedVec3 v0, v1, v2;  
@@ -21,7 +24,7 @@ namespace psxsplash {
       psyqo::PrimPieces::TPageAttr tpage; 
       uint16_t clutX;
       uint16_t clutY;
-      uint16_t padding;
+      uint16_t flags;
 
       /// Returns true if this triangle has no texture (vertex-color only).
       bool isUntextured() const {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -18,6 +18,7 @@
 #include "gtemath.hh"
 #include "skinmesh.hh"
 #include "uisystem.hh"
+#include "common/syscalls/syscalls.h"
 #ifdef PSXSPLASH_MEMOVERLAY
 #include "memoverlay.hh"
 #endif
@@ -126,7 +127,12 @@ void psxsplash::Renderer::processTriangle(
     Tri& tri, int32_t fogFarSZ,
     psyqo::OrderingTable<ORDERING_TABLE_SIZE>& ot,
     psyqo::BumpAllocator<BUMP_ALLOCATOR_SIZE>& balloc,
-    int depth) {
+    int depth,
+    psyqo::PrimPieces::UVCoords uvOffset) {
+
+    if (!(tri.flags & ANIM_FLAG)) {
+        uvOffset = { 0,0 };
+    }
 
     writeSafe<PseudoRegister::V0>(tri.v0);
     writeSafe<PseudoRegister::V1>(tri.v1);
@@ -216,8 +222,8 @@ void psxsplash::Renderer::processTriangle(
             childB.v2 = m; childB.uvC.u = mu; childB.uvC.v = mv; childB.colorC = mc;
         }
 
-        processTriangle(childA, fogFarSZ, ot, balloc, depth + 1);
-        processTriangle(childB, fogFarSZ, ot, balloc, depth + 1);
+        processTriangle(childA, fogFarSZ, ot, balloc, depth + 1, uvOffset);
+        processTriangle(childB, fogFarSZ, ot, balloc, depth + 1, uvOffset);
         return;
     }
 
@@ -286,9 +292,9 @@ void psxsplash::Renderer::processTriangle(
 
         auto& texP = balloc.allocateFragment<psyqo::Prim::GouraudTexturedTriangle>();
         texP.primitive.pointA = projected[0]; texP.primitive.pointB = projected[1]; texP.primitive.pointC = projected[2];
-        texP.primitive.uvA = tri.uvA;
-        texP.primitive.uvB = tri.uvB;
-        texP.primitive.uvC.u = tri.uvC.u; texP.primitive.uvC.v = tri.uvC.v;
+        texP.primitive.uvA.u = tri.uvA.u + uvOffset.u; texP.primitive.uvA.v = tri.uvA.v + uvOffset.v;
+        texP.primitive.uvB.u = tri.uvB.u + uvOffset.u; texP.primitive.uvB.v = tri.uvB.v + uvOffset.v;
+        texP.primitive.uvC.u = tri.uvC.u + uvOffset.u; texP.primitive.uvC.v = tri.uvC.v + uvOffset.v;
         texP.primitive.tpage = tri.tpage;
         texP.primitive.tpage.set(psyqo::Prim::TPageAttr::FullBackAndFullFront);
         psyqo::PrimPieces::ClutIndex clut(tri.clutX, tri.clutY);
@@ -300,9 +306,9 @@ void psxsplash::Renderer::processTriangle(
 
         auto& p = balloc.allocateFragment<psyqo::Prim::GouraudTexturedTriangle>();
         p.primitive.pointA = projected[0]; p.primitive.pointB = projected[1]; p.primitive.pointC = projected[2];
-        p.primitive.uvA = tri.uvA;
-        p.primitive.uvB = tri.uvB;
-        p.primitive.uvC.u = tri.uvC.u; p.primitive.uvC.v = tri.uvC.v;
+        p.primitive.uvA.u = tri.uvA.u + uvOffset.u; p.primitive.uvA.v = tri.uvA.v + uvOffset.v;
+        p.primitive.uvB.u = tri.uvB.u + uvOffset.u; p.primitive.uvB.v = tri.uvB.v + uvOffset.v;
+        p.primitive.uvC.u = tri.uvC.u + uvOffset.u; p.primitive.uvC.v = tri.uvC.v + uvOffset.v;
         p.primitive.tpage = tri.tpage;
         p.primitive.tpage.set(psyqo::Prim::TPageAttr::FullBackAndFullFront);
         psyqo::PrimPieces::ClutIndex clut(tri.clutX, tri.clutY);
@@ -336,7 +342,7 @@ void psxsplash::Renderer::Render(eastl::vector<GameObject*>& objects) {
         if (obj->isSkinned()) continue;
         setupObjectTransform(obj, cameraPosition);
         for (int i = 0; i < obj->polyCount; i++)
-            processTriangle(obj->polygons[i], fogFarSZ, ot, balloc);
+            processTriangle(obj->polygons[i], fogFarSZ, ot, balloc, 0, obj->uvOffset);
     }
     renderSkinnedObjects(objects, cameraPosition, fogFarSZ, ot, balloc);
     if (m_uiSystem) m_uiSystem->renderOT(m_gpu, ot, balloc);
@@ -393,7 +399,7 @@ void psxsplash::Renderer::RenderWithBVH(eastl::vector<GameObject*>& objects, con
             setupObjectTransform(obj, cameraPosition);
         }
         if (lastObjCulled) continue;
-        processTriangle(obj->polygons[ref.triangleIndex], fogFarSZ, ot, balloc);
+        processTriangle(obj->polygons[ref.triangleIndex], fogFarSZ, ot, balloc, 0, obj->uvOffset);
     }
 
     // Second pass: render dynamically-moved objects (their BVH references are stale).
@@ -408,7 +414,7 @@ void psxsplash::Renderer::RenderWithBVH(eastl::vector<GameObject*>& objects, con
         if (!frustum.testAABB(objBox)) continue;
         setupObjectTransform(obj, cameraPosition);
         for (int t = 0; t < obj->polyCount; t++) {
-            processTriangle(obj->polygons[t], fogFarSZ, ot, balloc);
+            processTriangle(obj->polygons[t], fogFarSZ, ot, balloc, 0, obj->uvOffset);
         }
     }
 
@@ -719,7 +725,7 @@ void psxsplash::Renderer::RenderWithRooms(eastl::vector<GameObject*>& objects,
                 setupObjectTransform(obj, cameraPosition);
             }
             if (lastObjCulled) continue;
-            processTriangle(obj->polygons[ref.triangleIndex], fogFarSZ, ot, balloc);
+            processTriangle(obj->polygons[ref.triangleIndex], fogFarSZ, ot, balloc, 0, obj->uvOffset);
         }
     };
 
@@ -1092,7 +1098,7 @@ void psxsplash::Renderer::RenderWithRooms(eastl::vector<GameObject*>& objects,
         if (!frustum.testAABB(objBox)) continue;
         setupObjectTransform(obj, cameraPosition);
         for (int t = 0; t < obj->polyCount; t++) {
-            processTriangle(obj->polygons[t], fogFarSZ, ot, balloc);
+            processTriangle(obj->polygons[t], fogFarSZ, ot, balloc, 0, obj->uvOffset);
         }
     }
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -18,7 +18,6 @@
 #include "gtemath.hh"
 #include "skinmesh.hh"
 #include "uisystem.hh"
-#include "common/syscalls/syscalls.h"
 #ifdef PSXSPLASH_MEMOVERLAY
 #include "memoverlay.hh"
 #endif
@@ -1331,6 +1330,8 @@ void psxsplash::Renderer::renderSkinnedObjects(
                 hasFog = (fogIR[0] > 0 || fogIR[1] > 0 || fogIR[2] > 0);
             }
 
+            psyqo::PrimPieces::UVCoords uvOffset = obj->uvOffset;
+
             // Emit GPU primitives
             if (tri.isUntextured()) {
                 if (hasFog) {
@@ -1359,8 +1360,9 @@ void psxsplash::Renderer::renderSkinnedObjects(
 
                 auto& texP = balloc.allocateFragment<psyqo::Prim::GouraudTexturedTriangle>();
                 texP.primitive.pointA = projected0; texP.primitive.pointB = projected1; texP.primitive.pointC = projected2;
-                texP.primitive.uvA = tri.uvA; texP.primitive.uvB = tri.uvB;
-                texP.primitive.uvC.u = tri.uvC.u; texP.primitive.uvC.v = tri.uvC.v;
+                texP.primitive.uvA.u = tri.uvA.u + uvOffset.u; texP.primitive.uvA.v = tri.uvA.v + uvOffset.v;
+                texP.primitive.uvB.u = tri.uvB.u + uvOffset.u; texP.primitive.uvB.v = tri.uvB.v + uvOffset.v;
+                texP.primitive.uvC.u = tri.uvC.u + uvOffset.u; texP.primitive.uvC.v = tri.uvC.v + uvOffset.v;
                 texP.primitive.tpage = tri.tpage;
                 texP.primitive.tpage.set(psyqo::Prim::TPageAttr::FullBackAndFullFront);
                 psyqo::PrimPieces::ClutIndex clut(tri.clutX, tri.clutY);
@@ -1371,8 +1373,9 @@ void psxsplash::Renderer::renderSkinnedObjects(
             } else {
                 auto& p = balloc.allocateFragment<psyqo::Prim::GouraudTexturedTriangle>();
                 p.primitive.pointA = projected0; p.primitive.pointB = projected1; p.primitive.pointC = projected2;
-                p.primitive.uvA = tri.uvA; p.primitive.uvB = tri.uvB;
-                p.primitive.uvC.u = tri.uvC.u; p.primitive.uvC.v = tri.uvC.v;
+                p.primitive.uvA.u = tri.uvA.u + uvOffset.u; p.primitive.uvA.v = tri.uvA.v + uvOffset.v;
+                p.primitive.uvB.u = tri.uvB.u + uvOffset.u; p.primitive.uvB.v = tri.uvB.v + uvOffset.v;
+                p.primitive.uvC.u = tri.uvC.u + uvOffset.u; p.primitive.uvC.v = tri.uvC.v + uvOffset.v;
                 p.primitive.tpage = tri.tpage;
                 p.primitive.tpage.set(psyqo::Prim::TPageAttr::FullBackAndFullFront);
                 psyqo::PrimPieces::ClutIndex clut(tri.clutX, tri.clutY);

--- a/src/renderer.hh
+++ b/src/renderer.hh
@@ -121,7 +121,7 @@ class Renderer final {
                          psyqo::OrderingTable<ORDERING_TABLE_SIZE>& ot,
                          psyqo::BumpAllocator<BUMP_ALLOCATOR_SIZE>& balloc,
                          int depth = 0,
-                         psyqo::PrimPieces::UVCoords uvOffset = {});
+                         psyqo::PrimPieces::UVCoords uvOffset = { 0 });
 
     void renderSkinnedObjects(eastl::vector<GameObject*>& objects,
                               const psyqo::Vec3& cameraPosition,

--- a/src/renderer.hh
+++ b/src/renderer.hh
@@ -120,7 +120,8 @@ class Renderer final {
     void processTriangle(Tri& tri, int32_t fogFarSZ,
                          psyqo::OrderingTable<ORDERING_TABLE_SIZE>& ot,
                          psyqo::BumpAllocator<BUMP_ALLOCATOR_SIZE>& balloc,
-                         int depth = 0);
+                         int depth = 0,
+                         psyqo::PrimPieces::UVCoords uvOffset = {});
 
     void renderSkinnedObjects(eastl::vector<GameObject*>& objects,
                               const psyqo::Vec3& cameraPosition,


### PR DESCRIPTION
This adds UV Offsets to the renderer and allows them to be manipulated at runtime using either lua scripting or the animation timeline.

The user must specify a material for the UV offset to be applied, allowing for offsets per material would require significant work and make the renderer slower.

Lua functions added:
Entity.SetUVOffset(entity, u, v)