### PR TITLE
Added more function declarations and definitions for Entities and UISystem

### DIFF
--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -627,6 +627,9 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
     L.push(UI_DrawTriangle);
     L.setField(-2, "DrawTriangle");
 
+    L.push(UI_DrawPixel);
+    L.setField(-2, "DrawPixel");
+
     L.setGlobal("UI");
 
     // ========================================================================
@@ -3794,6 +3797,68 @@ int LuaAPI::UI_DrawTriangle(lua_State* L) {
     thisTri.setColorC(psyqo::Color{ r3, g3, b3 });
 
     gpu.sendPrimitive(thisTri);
+
+    return 0;
+}
+
+// parameters: UI_DrawPixel(X, Y, {red, green, blue})
+// This is a heavy function and should only be used sparingly
+// Can be useful for replacing colors of a CLUT with your own
+int LuaAPI::UI_DrawPixel(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1) || !lua.isNumber(2) || !lua.isTable(3)) return 0;
+
+    uint16_t X = static_cast<uint16_t>(lua.toNumber(1));
+    uint16_t Y = static_cast<uint16_t>(lua.toNumber(2));
+
+    // get index 1 from table 3
+    lua.rawGetI(3, 1);
+    int colR = (int)lua.checkNumber(-1);
+    lua.pop();
+
+    lua.rawGetI(3, 2);
+    int colG = (int)lua.checkNumber(-1);
+    lua.pop();
+
+    lua.rawGetI(3, 3);
+    int colB = (int)lua.checkNumber(-1);
+    lua.pop();
+
+    auto& gpu = Renderer::GetInstance().getGPU();
+
+    // Set a region to plot the pixel
+    psyqo::Rect region = { .pos = {{.x = static_cast<int16_t>(X), .y = static_cast<int16_t>(Y)}}, .size = {{.w = 1, .h = 1}} };
+    psyqo::Prim::VRAMUpload upload;
+    upload.region = region;
+    gpu.sendPrimitive(upload);
+
+    // Clamp colors first
+    if (colR < 0)
+        colR = 0;
+    else if (colR > 255)
+        colR = 255;
+
+    if (colG < 0)
+        colG = 0;
+    else if (colG > 255)
+        colG = 255;
+
+    if (colB < 0)
+        colB = 0;
+    else if (colB > 255)
+        colB = 255;
+
+    // Perform color conversion second
+    uint16_t color =
+        ((colB >> 3) << 10) |
+        ((colG >> 3) << 5) |
+        (colR >> 3);
+
+    gpu.sendRaw(color);
+
+    // Flush the region after plotting the pixel
+    psyqo::Prim::FlushCache fc;
+    gpu.sendPrimitive(fc);
 
     return 0;
 }

--- a/src/luaapi.cpp
+++ b/src/luaapi.cpp
@@ -85,7 +85,7 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
     
     L.push(Entity_GetRotationY);
     L.setField(-2, "GetRotationY");
-    
+
     L.push(Entity_SetRotationY);
     L.setField(-2, "SetRotationY");
 
@@ -133,6 +133,12 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
 
     L.push(Entity_SetParent);
     L.setField(-2, "SetParent");
+
+    L.push(Entity_GetPolyCount);
+    L.setField(-2, "GetPolyCount");
+
+    L.push(Entity_GetPolyVertex);
+    L.setField(-2, "GetPolyVertex");
 
     L.setGlobal("Entity");
     
@@ -584,6 +590,24 @@ void LuaAPI::RegisterAll(psyqo::Lua& L, SceneManager* scene, CutscenePlayer* cut
 
     L.push(UI_GetSize);
     L.setField(-2, "GetSize");
+
+    L.push(UI_SetImageUVs);
+    L.setField(-2, "SetImageUVs");
+
+    L.push(UI_GetImageUVs);
+    L.setField(-2, "GetImageUVs");
+
+    L.push(UI_SetImageTexpage);
+    L.setField(-2, "SetImageTexpage");
+
+    L.push(UI_GetImageTexpage);
+    L.setField(-2, "GetImageTexpage");
+
+    L.push(UI_SetImageClut);
+    L.setField(-2, "SetImageClut");
+
+    L.push(UI_GetImageClut);
+    L.setField(-2, "GetImageClut");
 
     L.push(UI_SetProgressColors);
     L.setField(-2, "SetProgressColors");
@@ -1299,6 +1323,98 @@ int LuaAPI::Entity_SetParent(lua_State* L)
     goChild->rotation = goParent->rotation;
 
     return 0;
+}
+
+int LuaAPI::Entity_GetPolyCount(lua_State* L) {
+    psyqo::Lua lua(L);
+
+    if (!lua.isTable(1))
+    {
+        return 0;
+    }
+
+    lua.getField(1, "__cpp_ptr");
+    auto go = lua.toUserdata<GameObject>(-1);
+    lua.pop();
+
+    if (!go) return 0;
+
+    lua.pushNumber(go->polyCount);
+
+    return 1;
+}
+
+int LuaAPI::Entity_GetPolyVertex(lua_State* L) {
+	psyqo::Lua lua(L);
+
+	if (!lua.isTable(1) || !lua.isNumber(2) || !lua.isNumber(3))
+	{
+		return 0;
+	}
+
+	lua.getField(1, "__cpp_ptr");
+	auto go = lua.toUserdata<GameObject>(-1);
+	lua.pop();
+
+	int polyIndex = (int)lua.toNumber(2);
+    int vertIndex = (int)lua.toNumber(3);
+
+	if (!go) return 0;
+
+	// Check if polyIndex is in range
+	if (polyIndex < 0 || polyIndex >= go->polyCount)
+		return 0;
+
+	// Get the poly index
+    const auto& poly = go->polygons[polyIndex];
+    psyqo::Vec3 vec;
+    psyqo::Vec3 rotated;
+
+    // Get the correct vertex from the poly
+    switch (vertIndex)
+    {
+    case 0:
+        vec = poly.v0;
+        break;
+
+    case 1:
+        vec = poly.v1;
+        break;
+
+    case 2:
+        vec = poly.v2;
+        break;
+
+    default:
+        return 0;
+    }
+
+    // Get the object's rotation
+    rotated.x =
+        go->rotation.vs[0].x * vec.x +
+        go->rotation.vs[0].y * vec.y +
+        go->rotation.vs[0].z * vec.z;
+
+    rotated.y =
+        go->rotation.vs[1].x * vec.x +
+        go->rotation.vs[1].y * vec.y +
+        go->rotation.vs[1].z * vec.z;
+
+    rotated.z =
+        go->rotation.vs[2].x * vec.x +
+        go->rotation.vs[2].y * vec.y +
+        go->rotation.vs[2].z * vec.z;
+
+    // Get the object's position
+    rotated.x += go->position.x;
+    rotated.y += go->position.y;
+    rotated.z += go->position.z;
+
+    lua.push(rotated.x);
+    lua.push(rotated.y);
+    lua.push(rotated.z);
+
+    return 3;
 }
 
 // ============================================================================
@@ -3360,6 +3476,99 @@ int LuaAPI::UI_GetSize(lua_State* L) {
     s_uiSystem->getSize(handle, w, h);
     lua.pushNumber(static_cast<lua_Number>(w));
     lua.pushNumber(static_cast<lua_Number>(h));
+    return 2;
+}
+
+// parameters: UI_SetImageUVs(handle, u0, v0, u1, v1)
+int LuaAPI::UI_SetImageUVs(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) return 0;
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint8_t u0 = static_cast<uint8_t>(lua.toNumber(2));
+    uint8_t v0 = static_cast<uint8_t>(lua.toNumber(3));
+    uint8_t u1 = static_cast<uint8_t>(lua.toNumber(4));
+    uint8_t v1 = static_cast<uint8_t>(lua.toNumber(5));
+
+    s_uiSystem->setImageUVs(handle, u0, v0, u1, v1);
+
+    return 0;
+}
+
+// example usage: u0, v0, u1, v1 = UI_GetImageUVs(handle)
+int LuaAPI::UI_GetImageUVs(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) {
+        lua.pushNumber(0); lua.pushNumber(0);
+        lua.pushNumber(0); lua.pushNumber(0);
+        return 4;
+    }
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint8_t  u0, v0, u1, v1;
+
+    s_uiSystem->getImageUVs(handle, u0, v0, u1, v1);
+    lua.pushNumber(static_cast<lua_Number>(u0));
+    lua.pushNumber(static_cast<lua_Number>(v0));
+    lua.pushNumber(static_cast<lua_Number>(u1));
+    lua.pushNumber(static_cast<lua_Number>(v1));
+    return 4;
+}
+
+// parameters: UI_SetImageTexpage(handle, texpageX, texpageY)
+int LuaAPI::UI_SetImageTexpage(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) return 0;
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint8_t texpageX = static_cast<uint8_t>(lua.toNumber(2));
+    uint8_t texpageY = static_cast<uint8_t>(lua.toNumber(3));
+
+    s_uiSystem->setImageTexpage(handle, texpageX, texpageY);
+
+    return 0;
+}
+
+// example usage: texpageX, texpageY = UI_GetImageTexpage(handle)
+int LuaAPI::UI_GetImageTexpage(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) {
+        lua.pushNumber(0); lua.pushNumber(0);
+        return 2;
+    }
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint8_t texpageX, texpageY;
+
+    s_uiSystem->getImageTexpage(handle, texpageX, texpageY);
+    lua.pushNumber(static_cast<lua_Number>(texpageX));
+    lua.pushNumber(static_cast<lua_Number>(texpageY));
+    return 2;
+}
+
+// parameters: UI_SetImageClut(handle, clutX, clutY)
+int LuaAPI::UI_SetImageClut(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) return 0;
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint16_t clutX = static_cast<uint16_t>(lua.toNumber(2));
+    uint16_t clutY = static_cast<uint16_t>(lua.toNumber(3));
+
+    s_uiSystem->setImageClut(handle, clutX, clutY);
+
+    return 0;
+}
+
+// example usage: clutX, clutY = UI_GetImageClut(handle)
+int LuaAPI::UI_GetImageClut(lua_State* L) {
+    psyqo::Lua lua(L);
+    if (!s_uiSystem || !lua.isNumber(1)) {
+        lua.pushNumber(0);
+        lua.pushNumber(0);
+        return 2;
+    }
+    int handle = static_cast<int>(lua.toNumber(1));
+    uint16_t clutX, clutY;
+
+    s_uiSystem->getImageClut(handle, clutX, clutY);
+    lua.pushNumber(static_cast<lua_Number>(clutX));
+    lua.pushNumber(static_cast<lua_Number>(clutY));
     return 2;
 }
 

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -533,6 +533,8 @@ private:
     static int UI_DrawLine(lua_State* L);
     static int UI_DrawTriangle(lua_State* L);
     
+    static int UI_DrawPixel(lua_State* L);
+
     // ========================================================================
     // PLAYER API - Controlling the PsxPlayer
     // ========================================================================

--- a/src/luaapi.hh
+++ b/src/luaapi.hh
@@ -103,7 +103,7 @@ private:
     
     // Entity.GetRotationY(object) -> number (radians)
     static int Entity_GetRotationY(lua_State* L);
-    
+
     // Entity.SetRotationY(object, angle) -> nil
     static int Entity_SetRotationY(lua_State* L);
 
@@ -152,6 +152,12 @@ private:
 
     // Entity.SetParent(parent object, child object, Vec3 offset)
     static int Entity_SetParent(lua_State* L);
+
+    // Entity.GetPolyCount(object)
+    static int Entity_GetPolyCount(lua_State* L);
+
+    // Entity.GetPolyVertex(object, poly index, vertex index)
+    static int Entity_GetPolyVertex(lua_State* L);
 
     // ========================================================================
     // VEC3 API - Vector math
@@ -510,6 +516,12 @@ private:
     static int UI_GetPosition(lua_State* L);
     static int UI_SetSize(lua_State* L);
     static int UI_GetSize(lua_State* L);
+    static int UI_SetImageUVs(lua_State* L);
+    static int UI_GetImageUVs(lua_State* L);
+    static int UI_SetImageTexpage(lua_State* L);
+    static int UI_GetImageTexpage(lua_State* L);
+    static int UI_SetImageClut(lua_State* L);
+    static int UI_GetImageClut(lua_State* L);
     static int UI_SetProgressColors(lua_State* L);
     static int UI_GetElementType(lua_State* L);
     static int UI_GetElementCount(lua_State* L);

--- a/src/uisystem.cpp
+++ b/src/uisystem.cpp
@@ -666,6 +666,64 @@ void UISystem::getSize(int handle, int16_t& w, int16_t& h) const {
     h = rh;
 }
 
+void UISystem::setImageUVs(int handle, uint8_t u0, uint8_t v0, uint8_t u1, uint8_t v1) {
+    if (handle < 0 || handle >= m_elementCount) return;
+    const UIElement& el = m_elements[handle];
+    if (el.type != UIElementType::Image) return;
+    m_elements[handle].image.u0 = u0;
+    m_elements[handle].image.v0 = v0;
+    m_elements[handle].image.u1 = u1;
+    m_elements[handle].image.v1 = v1;
+
+    // Clear stretch anchors so size is explicit
+    //m_elements[handle].anchorMaxX = m_elements[handle].anchorMinX;
+    //m_elements[handle].anchorMaxY = m_elements[handle].anchorMinY;
+}
+
+void UISystem::getImageUVs(int handle, uint8_t& u0, uint8_t& v0, uint8_t& u1, uint8_t& v1) const {
+    if (handle < 0 || handle >= m_elementCount) { u0 = v0 = u1 = v1 = 0; return; }
+    u0 = m_elements[handle].image.u0;
+    v0 = m_elements[handle].image.v0;
+    u1 = m_elements[handle].image.u1;
+    v1 = m_elements[handle].image.v1;
+}
+
+void UISystem::setImageTexpage(int handle, uint8_t texpageX, uint8_t texpageY) {
+    if (handle < 0 || handle >= m_elementCount) return;
+    const UIElement& el = m_elements[handle];
+    if (el.type != UIElementType::Image) return;
+    m_elements[handle].image.texpageX = texpageX;
+    m_elements[handle].image.texpageY = texpageY;
+
+    // Clear stretch anchors so size is explicit
+    //m_elements[handle].anchorMaxX = m_elements[handle].anchorMinX;
+    //m_elements[handle].anchorMaxY = m_elements[handle].anchorMinY;
+}
+
+void UISystem::getImageTexpage(int handle, uint8_t& texpageX, uint8_t& texpageY) const {
+    if (handle < 0 || handle >= m_elementCount) { texpageX = texpageY = 0; return; }
+    texpageX = m_elements[handle].image.texpageX;
+    texpageY = m_elements[handle].image.texpageY;
+}
+
+void UISystem::setImageClut(int handle, uint16_t clutX, uint16_t clutY) {
+    if (handle < 0 || handle >= m_elementCount) return;
+    const UIElement& el = m_elements[handle];
+    if (el.type != UIElementType::Image) return;
+    m_elements[handle].image.clutX = clutX;
+    m_elements[handle].image.clutY = clutY;
+
+    // Clear stretch anchors so size is explicit
+    //m_elements[handle].anchorMaxX = m_elements[handle].anchorMinX;
+    //m_elements[handle].anchorMaxY = m_elements[handle].anchorMinY;
+}
+
+void UISystem::getImageClut(int handle, uint16_t& clutX, uint16_t& clutY) const {
+    if (handle < 0 || handle >= m_elementCount) { clutX = clutY = 0; return; }
+    clutX = m_elements[handle].image.clutX;
+    clutY = m_elements[handle].image.clutY;
+}
+
 void UISystem::setProgressColors(int handle, uint8_t bgR, uint8_t bgG, uint8_t bgB,
                                   uint8_t fillR, uint8_t fillG, uint8_t fillB) {
     if (handle < 0 || handle >= m_elementCount) return;

--- a/src/uisystem.hh
+++ b/src/uisystem.hh
@@ -120,6 +120,12 @@ public:
     void getPosition(int handle, int16_t& x, int16_t& y) const;
     void setSize(int handle, int16_t w, int16_t h);
     void getSize(int handle, int16_t& w, int16_t& h) const;
+    void setImageUVs(int handle, uint8_t u0, uint8_t v0, uint8_t u1, uint8_t v1);
+    void getImageUVs(int handle, uint8_t& u0, uint8_t& v0, uint8_t& u1, uint8_t& v1) const;
+    void setImageTexpage(int handle, uint8_t texpageX, uint8_t texpageY);
+    void getImageTexpage(int handle, uint8_t& texpageX, uint8_t& texpageY) const;
+    void setImageClut(int handle, uint16_t clutX, uint16_t clutY);
+    void getImageClut(int handle, uint16_t& clutX, uint16_t& clutY) const;
     void setProgressColors(int handle, uint8_t bgR, uint8_t bgG, uint8_t bgB,
                            uint8_t fillR, uint8_t fillG, uint8_t fillB);
     uint8_t getProgress(int handle) const;


### PR DESCRIPTION
Added function definitions for getting a polygon vertex from an entity and returning the polycount from an entity (these only work for static meshes at the moment), getting and setting UI image UVs, texpages, and cluts



-- Here is an example of how these entity functions can be used:
-- Note the use of Entity.GetPolyCount and Entity.GetPolyVertex
function onUpdate(self, dt)
    local gun_entity = Entity.Find("pistol")
    local gun_pos = Entity.GetPosition(gun_entity)
    local gun_polys = Entity.GetPolyCount(gun_entity)

    -- Get the vertices from the entity's polygons
    local newVertX_1, newVertY_1, newVertZ_1 = Entity.GetPolyVertex(gun_entity, poly_index, 0)
    local newVertX_2, newVertY_2, newVertZ_2 = Entity.GetPolyVertex(gun_entity, poly_index, 1)
    local newVertX_3, newVertY_3, newVertZ_3 = Entity.GetPolyVertex(gun_entity, poly_index, 2)

    -- Convert the 3D coordinates to 2D screen space
    local screenX_1, screenY_1 = PSXMath.Convert3DTo2D(Vec3.new(newVertX_1, newVertY_1, newVertZ_1))
    local screenX_2, screenY_2 = PSXMath.Convert3DTo2D(Vec3.new(newVertX_2, newVertY_2, newVertZ_2))
    local screenX_3, screenY_3 = PSXMath.Convert3DTo2D(Vec3.new(newVertX_3, newVertY_3, newVertZ_3))

    -- Draw some lines so we can see exactly where the polygons and vertices are
    UI.DrawLine({screenX_1, screenY_1}, {screenX_2, screenY_2}, {255, 0, 0})
    UI.DrawLine({screenX_2, screenY_2}, {screenX_3, screenY_3}, {0, 255, 0})
    UI.DrawLine({screenX_3, screenY_3}, {screenX_1, screenY_1}, {0, 0, 255})

    -- Watch poly_index change as the circle button is pressed
    if (Input.IsPressedPlayer1(Input.CIRCLE)) then
        if (poly_index < gun_polys - 1) then
            poly_index = (poly_index + 1)
        else
            poly_index = 0
        end
    end
end



-- Here is an example of how these UI image functions can be used:
-- For UVs, texpages, and cluts, it might be wise to store a copy of the originals in the Luascript, and then call them back later when needed.
checked_once = false

-- Setup variables for UI Image management
local coord_u0, coord_v0, coord_u1, coord_v1 = 0, 0, 0, 0
local tpageX, tpageY = 0, 0
local clutX, clutY = 0, 0

function onUpdate(self, dt)
    local canvas_ui = UI.FindCanvas("canvas")

    local left_image = UI.FindElement(canvas_ui, "left_image")
    local right_image = UI.FindElement(canvas_ui, "right_image")

    if (checked_once == false) then
        checked_once = true

	-- Get the UVs of the left_image and assign them to the right_image
        coord_u0, coord_v0, coord_u1, coord_v1 = UI.GetImageUVs(left_image)
        UI.SetImageUVs(right_image, coord_u0, coord_v0, coord_u1, coord_v1)

	-- Get the texture page location of the left_image and assign it to the right_image
        tpageX, tpageY = UI.GetImageTexpage(left_image)
        UI.SetImageTexpage(right_image, tpageX, tpageY)

	-- Get the clut page location of the left_image and assign it to the right_image
        clutX, clutY = UI.GetImageClut(left_image)
        UI.SetImageClut(right_image, clutX, clutY)
    end
end